### PR TITLE
Fix typo

### DIFF
--- a/src/com/github/hmdev/converter/AozoraEpub3Converter.java
+++ b/src/com/github/hmdev/converter/AozoraEpub3Converter.java
@@ -1735,7 +1735,7 @@ public class AozoraEpub3Converter
 		//行頭インデント 先頭が「『―（以外 半角空白は除去
 		if (this.forceIndent && ch.length > charStart+1) {
 			switch (ch[charStart]) {
-			case '　': case '「': case '『':  case '（': case '“': case '〈': case '【': case '〔': case '［': case '※':
+			case '　': case '「': case '『':  case '（': case '“': case '〝': case '〈': case '【': case '〔': case '［': case '※':
 				break;
 			case ' ': case ' ':
 				char c1 = ch[charStart+1];

--- a/src/com/github/hmdev/converter/AozoraEpub3Converter.java
+++ b/src/com/github/hmdev/converter/AozoraEpub3Converter.java
@@ -1735,7 +1735,7 @@ public class AozoraEpub3Converter
 		//行頭インデント 先頭が「『―（以外 半角空白は除去
 		if (this.forceIndent && ch.length > charStart+1) {
 			switch (ch[charStart]) {
-			case '　': case '「': case '『':  case '（': case '”': case '〈': case '【': case '〔': case '［': case '※':
+			case '　': case '「': case '『':  case '（': case '“': case '〈': case '【': case '〔': case '［': case '※':
 				break;
 			case ' ': case ' ':
 				char c1 = ch[charStart+1];


### PR DESCRIPTION
「“(U+201C)」であるべきところが「”(U+201D)」になっていました。

ダブルミニュート(U+301D)についてはNarou.rbが自前で「“→〝」の変換をするので、
念のためという感じです。