### PR TITLE
`epub:type`属性に出力する値を、`title-page`から`titlepage`に修正しました。

### DIFF
--- a/template/OPS/xhtml/xhtml_nav.vm
+++ b/template/OPS/xhtml/xhtml_nav.vm
@@ -54,7 +54,7 @@ nav#landmarks { display:none; }
 			<li><a epub:type="toc" href="nav.xhtml">目次</a></li>
 #end
 #if (${title_page})
-			<li><a epub:type="title-page" href="title.xhtml">扉</a></li>
+			<li><a epub:type="titlepage" href="title.xhtml">扉</a></li>
 #end
 #foreach(${sectionInfo} in ${sections})
 			<li><a epub:type="bodymatter" href="${sectionInfo.SectionId}.xhtml">本文</a></li>


### PR DESCRIPTION
`AozoraEpub3-1.1.0b45`で生成したepubファイルを[EPUB Validator (beta)](http://validator.idpf.org/)で検証したところ、エラーが出力されました。当プル・リクエストはそのエラーを解消するためのものです。

エラーとなったepub内のファイルは`OPS/xhtml/nav.xhtml`で、エラー内容は「Undefined property: 'title-page'.」でした。`nav.xhtml`を確認したところ、`epub:type`属性に`title-page`という値が設定されていましたが、[EPUB 3 Structural Semantics Vocabulary](http://www.idpf.org/epub/vocab/structure/)によると`title-page`ではなく`titlepage`でした。

当プル・リクエストにより、EPUB Validatorによるエラーが解消します。動作をご確認の上、取り込んでいただければ幸いです。
