### PR TITLE
Change to support OpenJDK

### DIFF
--- a/src/com/github/hmdev/image/ImageUtils.java
+++ b/src/com/github/hmdev/image/ImageUtils.java
@@ -109,6 +109,10 @@ public class ImageUtils
 				image.createGraphics().drawRenderedImage(ri, NO_TRANSFORM);
 			} catch (Exception e) {
 				image = ImageIO.read(is);
+			} catch (NoClassDefFoundError e) {
+				// OpenJDKではcom.sun.image.codec.jpegがなくてエラーになるので
+				// それをキャッチする
+				image = ImageIO.read(is);
 			}
 		} else {
 			image = ImageIO.read(is);


### PR DESCRIPTION
OpenJDKではcom.sun.image.codec.jpegが消えていてエラーが出ていたので修正です。

既にExceptionは受け付けるコードがあったのですが、OpenJDKではNoClassDefFoundErrorだったのでerrorを受け取るコードを追加しました。